### PR TITLE
security: add minimum release age for package installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ dependencies = [
     "pandas>=2.3.1",
     "pyairtable>=3.1.1",
 ]
+
+[tool.uv]
+exclude-newer = "7 days"


### PR DESCRIPTION
## Summary

Adds a minimum release age configuration so the package manager will not install any version published fewer than 7 days ago. This gives the community time to detect and yank compromised package versions before they reach our installs.

## Context

https://epochai.slack.com/archives/C09MV5HKSSV/p1774978655844979ZZ